### PR TITLE
Transform Shopify products output

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ Example using `curl`:
 curl http://localhost:3000/products
 ```
 
-This will return the JSON payload from Shopify's [Products API](https://shopify.dev/docs/api/admin-rest/2023-10/resources/product). If Shopify credentials are missing or invalid, the API responds with an error message.
+This endpoint returns a simplified JSON payload derived from Shopify's [Products API](https://shopify.dev/docs/api/admin-rest/2024-04/resources/product). Each product object contains the fields `productName`, `productId`, `imageUrl`, `price`, and `vendor`. If Shopify credentials are missing or invalid, the API responds with an error message.

--- a/src/shopify/shopify.service.ts
+++ b/src/shopify/shopify.service.ts
@@ -16,7 +16,7 @@ export class ShopifyService {
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
-    const url = `https://${this.shopDomain}/admin/api/2023-10/products.json`;
+    const url = `https://${this.shopDomain}/admin/api/2024-04/products.json`;
     try {
       const response = await axios.get(url, {
         headers: {
@@ -24,7 +24,14 @@ export class ShopifyService {
           'Content-Type': 'application/json',
         },
       });
-      return response.data;
+      const products = response.data?.products ?? [];
+      return products.map((p: any) => ({
+        productName: p.title,
+        productId: p.id,
+        imageUrl: p.image?.src ?? p.images?.[0]?.src ?? null,
+        price: p.variants?.[0]?.price,
+        vendor: p.vendor,
+      }));
     } catch (error: any) {
       throw new HttpException(
         error?.response?.data || 'Failed to fetch products',


### PR DESCRIPTION
## Summary
- update Shopify REST API version to 2024-04
- transform returned products to an array with productName, productId, imageUrl, price and vendor
- clarify README about simplified response

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b593c2de083249d1620f17700175e