### PR TITLE
Handle WhatsApp send errors

### DIFF
--- a/src/twilio/whatsapp.controller.ts
+++ b/src/twilio/whatsapp.controller.ts
@@ -21,7 +21,14 @@ export class WhatsappController {
       const twimlRes = new twiml.MessagingResponse();
       twimlRes.message(`Available products: ${names}`);
       // Also send a message via API in case TwiML not delivered
-      await this.twilioService.sendWhatsAppMessage(from, `Available products: ${names}`);
+      try {
+        await this.twilioService.sendWhatsAppMessage(
+          from,
+          `Available products: ${names}`,
+        );
+      } catch (error) {
+        console.error('Failed to send proactive WhatsApp message', error);
+      }
       return twimlRes.toString();
     }
     const twimlRes = new twiml.MessagingResponse();


### PR DESCRIPTION
## Summary
- avoid crashing the webhook when sending proactive WhatsApp messages

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68505ee467488324815af282be8c8fa8