### PR TITLE
Handle WhatsApp send errors

### DIFF
--- a/src/twilio/twilio.service.ts
+++ b/src/twilio/twilio.service.ts
@@ -13,6 +13,7 @@ export class TwilioService {
 
   async sendWhatsAppMessage(to: string, body: string) {
     const from = `whatsapp:${process.env.TWILIO_WHATSAPP_NUMBER}`;
+    console.log('Sending WhatsApp from', from, 'to', `whatsapp:${to}`);
     return this.client.messages.create({
       from,
       to: `whatsapp:${to}`,

--- a/src/twilio/whatsapp.controller.ts
+++ b/src/twilio/whatsapp.controller.ts
@@ -21,7 +21,15 @@ export class WhatsappController {
       const twimlRes = new twiml.MessagingResponse();
       twimlRes.message(`Available products: ${names}`);
       // Also send a message via API in case TwiML not delivered
-      await this.twilioService.sendWhatsAppMessage(from, `Available products: ${names}`);
+      console.log('From:', from);
+      try {
+        await this.twilioService.sendWhatsAppMessage(
+          from,
+          `Available products: ${names}`,
+        );
+      } catch (error) {
+        console.error('Failed to send proactive WhatsApp message', error);
+      }
       return twimlRes.toString();
     }
     const twimlRes = new twiml.MessagingResponse();


### PR DESCRIPTION
## Summary
- avoid crashing the webhook when sending proactive WhatsApp messages
- log the sender's phone number before trying to send proactive message
- log from/to data in Twilio service when sending WhatsApp

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68505ee467488324815af282be8c8fa8