### PR TITLE
Add OpenAI agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ npm install
 - `TWILIO_ACCOUNT_SID` – your Twilio account SID
 - `TWILIO_AUTH_TOKEN` – the auth token for your Twilio account
 - `TWILIO_WHATSAPP_NUMBER` – the Twilio WhatsApp-enabled number to send messages from
+- `OPENAI_API_KEY` – your OpenAI API key for GPT-4 access
 
 
 You can create a `.env` file or export them in your shell before running the app.

--- a/src/openai/openai.module.ts
+++ b/src/openai/openai.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { OpenaiService } from './openai.service';
+
+@Module({
+  providers: [OpenaiService],
+  exports: [OpenaiService],
+})
+export class OpenaiModule {}

--- a/src/openai/openai.service.ts
+++ b/src/openai/openai.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import axios from 'axios';
+
+@Injectable()
+export class OpenaiService {
+  private readonly apiKey = process.env.OPENAI_API_KEY;
+  private readonly apiUrl = 'https://api.openai.com/v1/chat/completions';
+
+  async chat(messages: { role: string; content: string }[]): Promise<string> {
+    if (!this.apiKey) {
+      throw new Error('OPENAI_API_KEY is not configured');
+    }
+    const response = await axios.post(
+      this.apiUrl,
+      {
+        model: 'gpt-4',
+        messages,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    return response.data?.choices?.[0]?.message?.content?.trim() ?? '';
+  }
+}

--- a/src/twilio/twilio.module.ts
+++ b/src/twilio/twilio.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { TwilioService } from './twilio.service';
 import { WhatsappController } from './whatsapp.controller';
 import { ShopifyModule } from '../shopify/shopify.module';
+import { OpenaiModule } from '../openai/openai.module';
 
 @Module({
-  imports: [ShopifyModule],
+  imports: [ShopifyModule, OpenaiModule],
   providers: [TwilioService],
   controllers: [WhatsappController],
 })


### PR DESCRIPTION
## Summary
- integrate a simple OpenAI service with GPT‑4
- wire the OpenAI module into Twilio flow
- modify WhatsApp controller to use GPT‑4 and list products
- document new `OPENAI_API_KEY` env var

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68508ff706e083248329182332c48525