### PR TITLE
Add product lookup endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,32 @@ curl http://localhost:3000/products
 
 This endpoint returns a simplified JSON payload derived from Shopify's [Products API](https://shopify.dev/docs/api/admin-rest/2024-04/resources/product). Each product object contains the fields `productName`, `productId`, `imageUrl`, `price`, and `vendor`. If Shopify credentials are missing or invalid, the API responds with an error message.
 
+### Get a single product
+
+```
+GET /products/:id
+```
+
+Retrieve the raw product information for the given product ID directly from Shopify.
+
+Example:
+
+```bash
+curl http://localhost:3000/products/<id>
+```
+
+### Get product image
+
+```
+GET /products/:id/image
+```
+
+Returns a JSON object with the first image URL of the specified product.
+
+```bash
+curl http://localhost:3000/products/<id>/image
+```
+
 ### WhatsApp webhook
 
 Twilio will send incoming WhatsApp messages to the `/whatsapp/webhook` endpoint. If the user sends a message containing the word `"products"`, the bot replies with the list of available product names from Shopify.

--- a/src/shopify/shopify.controller.ts
+++ b/src/shopify/shopify.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Param } from '@nestjs/common';
 import { ShopifyService } from './shopify.service';
 
 @Controller('products')
@@ -8,5 +8,16 @@ export class ShopifyController {
   @Get()
   async findAll() {
     return this.shopifyService.getProducts();
+  }
+
+  @Get(':id')
+  async findOne(@Param('id') id: string) {
+    return this.shopifyService.getProduct(id);
+  }
+
+  @Get(':id/image')
+  async findImage(@Param('id') id: string) {
+    const imageUrl = await this.shopifyService.getProductImage(id);
+    return { imageUrl };
   }
 }

--- a/src/shopify/shopify.service.ts
+++ b/src/shopify/shopify.service.ts
@@ -40,4 +40,54 @@ export class ShopifyService {
       );
     }
   }
+
+  async getProduct(productId: string): Promise<any> {
+    if (!this.shopDomain || !this.accessToken) {
+      throw new HttpException(
+        'Shopify credentials are not configured',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+    const url = `https://${this.shopDomain}/admin/api/2024-04/products/${productId}.json`;
+    try {
+      const response = await axios.get(url, {
+        headers: {
+          'X-Shopify-Access-Token': this.accessToken,
+          'Content-Type': 'application/json',
+        },
+      });
+      return response.data?.product;
+    } catch (error: any) {
+      throw new HttpException(
+        error?.response?.data || 'Failed to fetch product',
+        error?.response?.status || HttpStatus.BAD_GATEWAY,
+
+      );
+    }
+  }
+
+  async getProductImage(productId: string): Promise<string | null> {
+    if (!this.shopDomain || !this.accessToken) {
+      throw new HttpException(
+        'Shopify credentials are not configured',
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+    const url = `https://${this.shopDomain}/admin/api/2024-04/products/${productId}/images.json`;
+    try {
+      const response = await axios.get(url, {
+        headers: {
+          'X-Shopify-Access-Token': this.accessToken,
+          'Content-Type': 'application/json',
+        },
+      });
+      return response.data?.images?.[0]?.src ?? null;
+    } catch (error: any) {
+      throw new HttpException(
+        error?.response?.data || 'Failed to fetch product image',
+        error?.response?.status || HttpStatus.BAD_GATEWAY,
+
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- query Shopify for a single product
- allow retrieving a product image directly
- document new API endpoints

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685099a03900832483f965f5497051ca