### PR TITLE
Add WhatsApp product images and catalog details

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ POST /whatsapp/webhook
 ```
 
 Configure this URL as your WhatsApp webhook in the Twilio Console.
+If a message contains a product name or ID, the bot attaches that product's image in the reply. The assistant also receives product IDs, prices, vendors, and image URLs so it can answer detailed catalog questions.


### PR DESCRIPTION
## Summary
- give the OpenAI assistant full product info
- attach the product image in WhatsApp replies when a user mentions that item
- document the new WhatsApp behavior

## Testing
- `npm run build`
- `npm start` *(fails: accountSid must start with AC)*

------
https://chatgpt.com/codex/tasks/task_e_68509c9cb62c832498be50e1fcee2003