### PR TITLE
Use OpenAI for product matching

### DIFF
--- a/src/openai/openai.service.ts
+++ b/src/openai/openai.service.ts
@@ -25,4 +25,31 @@ export class OpenaiService {
     );
     return response.data?.choices?.[0]?.message?.content?.trim() ?? '';
   }
+
+  async matchProduct(
+    userMessage: string,
+    catalog: { productName: string; productId: string | number }[],
+  ): Promise<string | null> {
+    const catalogList = catalog
+      .map((p) => `${p.productName} (id: ${p.productId})`)
+      .join('; ');
+    const messages = [
+      {
+        role: 'system',
+        content:
+          'Identify if the user is referring to a product from the catalog. ' +
+          'Reply ONLY with the id of the product if there is a clear match. ' +
+          'Reply with "none" if no product matches. ' +
+          `Catalog: ${catalogList}.`,
+      },
+      { role: 'user', content: userMessage },
+    ];
+
+    const reply = await this.chat(messages);
+    const id = reply.trim().toLowerCase();
+    if (id === 'none') {
+      return null;
+    }
+    return id;
+  }
 }

--- a/src/twilio/whatsapp.controller.ts
+++ b/src/twilio/whatsapp.controller.ts
@@ -47,11 +47,10 @@ export class WhatsappController {
 
     const twimlRes = new twiml.MessagingResponse();
 
-    const matchedProduct = catalog.find(
-      (p: any) =>
-        userMessage.toLowerCase().includes(p.productName.toLowerCase()) ||
-        userMessage.includes(String(p.productId)),
-    );
+    const matchedId = await this.openaiService.matchProduct(userMessage, catalog);
+    const matchedProduct = matchedId
+      ? catalog.find((p: any) => String(p.productId) === matchedId)
+      : undefined;
 
     let messageBody = reply;
     if (matchedProduct) {


### PR DESCRIPTION
## Summary
- use OpenAI to detect product references instead of simple string matching
- expose `matchProduct` helper in `OpenaiService`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850a74812608324b4a09f53adddc783