### PR TITLE
Add intent based whatsapp service

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,14 @@ curl http://localhost:3000/products/<id>/image
 
 ### WhatsApp webhook
 
-Twilio will send incoming WhatsApp messages to the `/whatsapp/webhook` endpoint. If the user sends a message containing the word `"products"`, the bot replies with the list of available product names from Shopify.
+Twilio will send incoming WhatsApp messages to the `/whatsapp/webhook` endpoint.
+The assistant first detects the user's intent and supports the following intents:
+`store-information`, `list-products`, `view-product-detail` and `buy-product`.
+OpenAI is used both for intent detection and for generating the reply.
 
 ```
 POST /whatsapp/webhook
 ```
 
 Configure this URL as your WhatsApp webhook in the Twilio Console.
-If a message contains a product name or ID, the bot attaches that product's image in the reply. The assistant also receives product IDs, prices, vendors, and image URLs so it can answer detailed catalog questions.
+When a product is mentioned, the bot attaches the product image instead of sharing its URL. The assistant receives product IDs, prices, vendors and image URLs so it can answer detailed catalog questions and provide a link to view the product in the store.

--- a/src/openai/openai.service.ts
+++ b/src/openai/openai.service.ts
@@ -1,6 +1,16 @@
 import { Injectable } from '@nestjs/common';
 import axios from 'axios';
 
+export interface CatalogItem {
+  productName: string;
+  productId: string | number;
+  handle?: string;
+  imageUrl?: string | null;
+  price?: string | number;
+  vendor?: string;
+  description?: string;
+}
+
 @Injectable()
 export class OpenaiService {
   private readonly apiKey = process.env.OPENAI_API_KEY;
@@ -28,7 +38,7 @@ export class OpenaiService {
 
   async matchProduct(
     userMessage: string,
-    catalog: { productName: string; productId: string | number }[],
+    catalog: CatalogItem[],
   ): Promise<string | null> {
     const catalogList = catalog
       .map((p) => `${p.productName} (id: ${p.productId})`)
@@ -51,5 +61,102 @@ export class OpenaiService {
       return null;
     }
     return id;
+  }
+
+  async analyzeIntent(userMessage: string): Promise<string> {
+    const messages = [
+      {
+        role: 'system',
+        content:
+          'Identify the user intent. Possible intents: store-information, list-products, view-product-detail, buy-product. ' +
+          'Reply ONLY with one of the intent labels.',
+      },
+      { role: 'user', content: userMessage },
+    ];
+    const reply = await this.chat(messages);
+    return reply.trim().toLowerCase();
+  }
+
+  async generateStoreInformationResponse(userMessage: string): Promise<string> {
+    const domain = process.env.SHOPIFY_SHOP_DOMAIN || 'our online store';
+    const messages = [
+      {
+        role: 'system',
+        content:
+          `You are a helpful e-commerce assistant for the store at ${domain}. Provide store information and policies without mentioning internal APIs.`,
+      },
+      { role: 'user', content: userMessage },
+    ];
+    return this.chat(messages);
+  }
+
+  async generateListProductsResponse(
+    userMessage: string,
+    catalog: CatalogItem[],
+  ): Promise<string> {
+    const catalogInfo = catalog
+      .map(
+        (p) => `${p.productName} (price: ${p.price}, vendor: ${p.vendor})`,
+      )
+      .join('; ');
+    const messages = [
+      {
+        role: 'system',
+        content:
+          'You are a helpful e-commerce assistant. Provide a concise list of products based on the catalog. ' +
+          `Catalog: ${catalogInfo}.`,
+      },
+      { role: 'user', content: userMessage },
+    ];
+    return this.chat(messages);
+  }
+
+  async generateProductDetailResponse(
+    userMessage: string,
+    product: CatalogItem,
+  ): Promise<string> {
+    const domain = process.env.SHOPIFY_SHOP_DOMAIN;
+    const link = domain && product.handle ? `https://${domain}/products/${product.handle}` : '';
+    const description = product.description
+      ? product.description.replace(/<[^>]+>/g, '')
+      : '';
+    const messages = [
+      {
+        role: 'system',
+        content:
+          `You are a helpful e-commerce assistant. Provide concise details about the product including the name, price, vendor and brief description. Mention that the product image is attached and do not disclose its URL. ${link ? 'Link: ' + link + '.' : ''} ` +
+          `Product: ${product.productName} (price: ${product.price}, vendor: ${product.vendor}). ${description ? 'Description: ' + description : ''}`,
+      },
+      { role: 'user', content: userMessage },
+    ];
+    return this.chat(messages);
+  }
+
+  async generateBuyProductResponse(
+    userMessage: string,
+    product?: CatalogItem,
+  ): Promise<string> {
+    if (product) {
+      const domain = process.env.SHOPIFY_SHOP_DOMAIN;
+      const link = domain && product.handle ? `https://${domain}/products/${product.handle}` : '';
+      const messages = [
+        {
+          role: 'system',
+          content:
+            `You are a helpful e-commerce assistant. Help the user purchase the product ${product.productName} (price: ${product.price}, vendor: ${product.vendor}). ${link ? 'Link: ' + link + '.' : ''}`,
+        },
+        { role: 'user', content: userMessage },
+      ];
+      return this.chat(messages);
+    }
+    const messages = [
+      {
+        role: 'system',
+        content:
+          'You are a helpful e-commerce assistant. The requested product was not found.',
+      },
+      { role: 'user', content: userMessage },
+    ];
+    return this.chat(messages);
   }
 }

--- a/src/twilio/twilio.module.ts
+++ b/src/twilio/twilio.module.ts
@@ -3,10 +3,11 @@ import { TwilioService } from './twilio.service';
 import { WhatsappController } from './whatsapp.controller';
 import { ShopifyModule } from '../shopify/shopify.module';
 import { OpenaiModule } from '../openai/openai.module';
+import { WhatsappService } from './whatsapp.service';
 
 @Module({
   imports: [ShopifyModule, OpenaiModule],
-  providers: [TwilioService],
+  providers: [TwilioService, WhatsappService],
   controllers: [WhatsappController],
 })
 export class TwilioModule {}

--- a/src/twilio/whatsapp.service.ts
+++ b/src/twilio/whatsapp.service.ts
@@ -1,0 +1,105 @@
+import { Injectable } from '@nestjs/common';
+import { ShopifyService } from '../shopify/shopify.service';
+import { OpenaiService, CatalogItem } from '../openai/openai.service';
+
+@Injectable()
+export class WhatsappService {
+  constructor(
+    private readonly shopifyService: ShopifyService,
+    private readonly openaiService: OpenaiService,
+  ) {}
+
+  private buildCatalog(raw: any[]): CatalogItem[] {
+    return raw.map((p: any) => ({
+      productName: p.title,
+      productId: p.id,
+      handle: p.handle,
+      imageUrl: p.image?.src ?? p.images?.[0]?.src ?? null,
+      price: p.variants?.[0]?.price,
+      vendor: p.vendor,
+      description: p.body_html || p.body || p.description || '',
+    }));
+  }
+
+  async processMessage(
+    userMessage: string,
+  ): Promise<{ body: string; mediaUrl?: string }> {
+    const raw = await this.shopifyService.getProducts();
+    const catalog = this.buildCatalog(raw.products ?? []);
+
+    const intent = await this.openaiService.analyzeIntent(userMessage);
+
+    let body = '';
+    let mediaUrl: string | undefined;
+
+    switch (intent) {
+      case 'store-information':
+        body = await this.openaiService.generateStoreInformationResponse(
+          userMessage,
+        );
+        break;
+      case 'list-products':
+        body = await this.openaiService.generateListProductsResponse(
+          userMessage,
+          catalog,
+        );
+        break;
+      case 'view-product-detail': {
+        const matchedId = await this.openaiService.matchProduct(
+          userMessage,
+          catalog,
+        );
+        const product = matchedId
+          ? catalog.find((p) => String(p.productId) === matchedId)
+          : undefined;
+        if (product) {
+          body = await this.openaiService.generateProductDetailResponse(
+            userMessage,
+            product,
+          );
+          if (product.imageUrl) {
+            mediaUrl = product.imageUrl;
+          }
+        } else {
+          body = await this.openaiService.chat([
+            {
+              role: 'system',
+              content:
+                'You are a helpful e-commerce assistant. The requested product was not found.',
+            },
+            { role: 'user', content: userMessage },
+          ]);
+        }
+        break;
+      }
+      case 'buy-product': {
+        const matchedId = await this.openaiService.matchProduct(
+          userMessage,
+          catalog,
+        );
+        const product = matchedId
+          ? catalog.find((p) => String(p.productId) === matchedId)
+          : undefined;
+        body = await this.openaiService.generateBuyProductResponse(
+          userMessage,
+          product,
+        );
+        if (product?.imageUrl) {
+          mediaUrl = product.imageUrl;
+        }
+        break;
+      }
+      default:
+        body = await this.openaiService.chat([
+          {
+            role: 'system',
+            content: 'You are a helpful e-commerce assistant.',
+          },
+          { role: 'user', content: userMessage },
+        ]);
+    }
+
+    return { body, mediaUrl };
+  }
+}
+


### PR DESCRIPTION
## Summary
- detect user intents via OpenAI and expose catalog data type
- implement per-intent response helpers in OpenAI service
- create WhatsappService to encapsulate intent logic
- use new service from controller
- document intents in README
- tweak product detail responses to mention image attachment

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850a9a0dd7c8324bcdce07d42c28aea