### PR TITLE
Implement product link button in WhatsApp replies

### DIFF
--- a/src/twilio/twilio.service.ts
+++ b/src/twilio/twilio.service.ts
@@ -11,13 +11,27 @@ export class TwilioService {
     this.client = new Twilio(accountSid, authToken);
   }
 
-  async sendWhatsAppMessage(to: string, body: string) {
+  async sendWhatsAppMessage(
+    to: string,
+    body: string,
+    options?: { mediaUrl?: string; actionUrl?: string },
+  ) {
     const from = `whatsapp:${process.env.TWILIO_WHATSAPP_NUMBER}`;
-    console.log('Sending WhatsApp from', from, 'to', `whatsapp:${to}`);
-    return this.client.messages.create({
+    const payload: Record<string, any> = {
       from,
       to: `whatsapp:${to}`,
       body,
-    });
+    };
+
+    if (options?.mediaUrl) {
+      payload.mediaUrl = [options.mediaUrl];
+    }
+
+    if (options?.actionUrl) {
+      payload.persistentAction = [options.actionUrl];
+    }
+
+    console.log('Sending WhatsApp', payload);
+    return this.client.messages.create(payload as any);
   }
 }

--- a/src/twilio/whatsapp.controller.ts
+++ b/src/twilio/whatsapp.controller.ts
@@ -1,11 +1,13 @@
 import { Body, Controller, Header, Post } from '@nestjs/common';
 import { WhatsappService } from './whatsapp.service';
+import { TwilioService } from './twilio.service';
 import { twiml } from 'twilio';
 
 @Controller('whatsapp')
 export class WhatsappController {
   constructor(
     private readonly whatsappService: WhatsappService,
+    private readonly twilioService: TwilioService,
   ) {}
 
   @Post('webhook')
@@ -14,23 +16,24 @@ export class WhatsappController {
     const from = body.From?.replace('whatsapp:', '') || '';
     const userMessage = body.Body || '';
 
-    const { body: reply, mediaUrl } = await this.whatsappService.processMessage(
-      userMessage,
-    );
+    const { body: reply, mediaUrl, actionUrl } =
+      await this.whatsappService.processMessage(userMessage);
 
+    console.log('From:', from);
+
+    if (actionUrl) {
+      await this.twilioService.sendWhatsAppMessage(from, reply, {
+        mediaUrl,
+        actionUrl,
+      });
+      // Return empty TwiML so Twilio does not send an additional message
+      return new twiml.MessagingResponse().toString();
+    }
     const twimlRes = new twiml.MessagingResponse();
-
     const msg = twimlRes.message(reply);
     if (mediaUrl) {
       msg.media(mediaUrl);
     }
-
-
-    console.log('From:', from);
-
-    // Twilio automatically sends the message specified in the TwiML response.
-    // Avoid proactively sending the same message again to prevent duplicates.
-
     return twimlRes.toString();
   }
 }

--- a/src/twilio/whatsapp.service.ts
+++ b/src/twilio/whatsapp.service.ts
@@ -23,7 +23,7 @@ export class WhatsappService {
 
   async processMessage(
     userMessage: string,
-  ): Promise<{ body: string; mediaUrl?: string }> {
+  ): Promise<{ body: string; mediaUrl?: string; actionUrl?: string }> {
     const raw = await this.shopifyService.getProducts();
     const catalog = this.buildCatalog(raw.products ?? []);
 
@@ -31,6 +31,7 @@ export class WhatsappService {
 
     let body = '';
     let mediaUrl: string | undefined;
+    let actionUrl: string | undefined;
 
     switch (intent) {
       case 'store-information':
@@ -59,6 +60,10 @@ export class WhatsappService {
           );
           if (product.imageUrl) {
             mediaUrl = product.imageUrl;
+          }
+          const domain = process.env.SHOPIFY_SHOP_DOMAIN;
+          if (domain && product.handle) {
+            actionUrl = `https://${domain}/products/${product.handle}`;
           }
         } else {
           body = await this.openaiService.chat([
@@ -99,7 +104,7 @@ export class WhatsappService {
         ]);
     }
 
-    return { body, mediaUrl };
+    return { body, mediaUrl, actionUrl };
   }
 }
 


### PR DESCRIPTION
## Summary
- return product link from `WhatsappService`
- add WhatsApp persistentAction to message so link appears as a button
- send message via Twilio API when persistentAction is present

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850ae783e948324ada3e7dbffb7e4af