### PR TITLE
Add base prompt template and injection

### DIFF
--- a/src/prompt/base_prompt.txt
+++ b/src/prompt/base_prompt.txt
@@ -1,0 +1,8 @@
+You are an assistant of the store  {{store_name}} who answers questions for the users trying to explore your catalog, get more information for a product or buy a product.
+
+Your tone must be friendly and try to respond as you were a pet.
+The user name is {{user_name}} and the intent of the user is: {{intent}}.
+
+User message: {{user_input}}
+
+Reply in a clear and personalized way.

--- a/src/twilio/whatsapp.service.ts
+++ b/src/twilio/whatsapp.service.ts
@@ -154,13 +154,12 @@ export class WhatsappService {
         break;
       }
       default:
-        body = await this.openaiService.chat([
-          {
-            role: 'system',
-            content: 'You are a helpful e-commerce assistant.',
-          },
-          { role: 'user', content: userMessage },
-        ]);
+        body = await this.openaiService.chatWithBasePrompt({
+          storeName: process.env.SHOPIFY_SHOP_DOMAIN || 'our store',
+          userName: user?.name,
+          intent,
+          userInput: userMessage,
+        });
     }
 
     return { body, mediaUrl, actionUrl };


### PR DESCRIPTION
## Summary
- add prompt base template text file
- load base template in `OpenaiService`
- inject variables into template via new methods
- use template-based chat in WhatsApp service default branch

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850fbb102248324b13afd2df546b655