### PR TITLE
Update intent prompts with base text

### DIFF
--- a/src/openai/openai.service.ts
+++ b/src/openai/openai.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import axios from 'axios';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 
 export interface CatalogItem {
   productName: string;
@@ -15,6 +17,43 @@ export interface CatalogItem {
 export class OpenaiService {
   private readonly apiKey = process.env.OPENAI_API_KEY;
   private readonly apiUrl = 'https://api.openai.com/v1/chat/completions';
+  private readonly templates = {
+    base: readFileSync(
+      join(process.cwd(), 'src/prompt/base_prompt.txt'),
+      'utf8',
+    ),
+    storeInfo: readFileSync(
+      join(process.cwd(), 'src/prompt/store_information_prompt.txt'),
+      'utf8',
+    ),
+    listProducts: readFileSync(
+      join(process.cwd(), 'src/prompt/list_products_prompt.txt'),
+      'utf8',
+    ),
+    productDetail: readFileSync(
+      join(process.cwd(), 'src/prompt/product_detail_prompt.txt'),
+      'utf8',
+    ),
+    buyProduct: readFileSync(
+      join(process.cwd(), 'src/prompt/buy_product_prompt.txt'),
+      'utf8',
+    ),
+    productNotFound: readFileSync(
+      join(process.cwd(), 'src/prompt/product_not_found_prompt.txt'),
+      'utf8',
+    ),
+  } as const;
+
+  private fillTemplate(
+    template: string,
+    variables: Record<string, string | undefined>,
+  ): string {
+    let result = template;
+    for (const [key, value] of Object.entries(variables)) {
+      result = result.replace(new RegExp(`{{${key}}}`, 'g'), value ?? '');
+    }
+    return result;
+  }
 
   async chat(messages: { role: string; content: string }[]): Promise<string> {
     if (!this.apiKey) {
@@ -77,86 +116,133 @@ export class OpenaiService {
     return reply.trim().toLowerCase();
   }
 
-  async generateStoreInformationResponse(userMessage: string): Promise<string> {
+  async generateStoreInformationResponse(
+    userMessage: string,
+    storeName: string,
+    userName?: string,
+  ): Promise<string> {
     const domain = process.env.SHOPIFY_SHOP_DOMAIN || 'our online store';
-    const messages = [
-      {
-        role: 'system',
-        content:
-          `You are a helpful e-commerce assistant for the store at ${domain}. Provide store information and policies without mentioning internal APIs.`,
-      },
-      { role: 'user', content: userMessage },
-    ];
-    return this.chat(messages);
+    const prompt = this.fillTemplate(this.templates.storeInfo, {
+      store_domain: domain,
+      store_name: storeName,
+      user_name: userName ?? 'customer',
+      intent: 'store-information',
+      user_input: userMessage,
+    });
+    return this.chat([{ role: 'system', content: prompt }]);
   }
 
   async generateListProductsResponse(
     userMessage: string,
     catalog: CatalogItem[],
+    storeName: string,
+    userName?: string,
   ): Promise<string> {
     const catalogInfo = catalog
       .map(
         (p) => `${p.productName} (price: ${p.price}, vendor: ${p.vendor})`,
       )
       .join('; ');
-    const messages = [
-      {
-        role: 'system',
-        content:
-          'You are a helpful e-commerce assistant. Provide a concise list of products based on the catalog. ' +
-          `Catalog: ${catalogInfo}.`,
-      },
-      { role: 'user', content: userMessage },
-    ];
-    return this.chat(messages);
+    const prompt = this.fillTemplate(this.templates.listProducts, {
+      catalog_info: catalogInfo,
+      store_name: storeName,
+      user_name: userName ?? 'customer',
+      intent: 'list-products',
+      user_input: userMessage,
+    });
+    return this.chat([{ role: 'system', content: prompt }]);
   }
 
   async generateProductDetailResponse(
     userMessage: string,
     product: CatalogItem,
+    storeName: string,
+    userName?: string,
   ): Promise<string> {
     const domain = process.env.SHOPIFY_SHOP_DOMAIN;
     const link = domain && product.handle ? `https://${domain}/products/${product.handle}` : '';
     const description = product.description
       ? product.description.replace(/<[^>]+>/g, '')
       : '';
-    const messages = [
-      {
-        role: 'system',
-        content:
-          `You are a helpful e-commerce assistant. Provide concise details about the product including the name, price, vendor and brief description. Mention that the product image is attached and do not disclose its URL. ${link ? 'Link: ' + link + '.' : ''} ` +
-          `Product: ${product.productName} (price: ${product.price}, vendor: ${product.vendor}). ${description ? 'Description: ' + description : ''}`,
-      },
-      { role: 'user', content: userMessage },
-    ];
-    return this.chat(messages);
+    const prompt = this.fillTemplate(this.templates.productDetail, {
+      link: link ? `Link: ${link}.` : '',
+      product_name: product.productName,
+      price: String(product.price),
+      vendor: product.vendor ?? '',
+      description: description ? `Description: ${description}` : '',
+      store_name: storeName,
+      user_name: userName ?? 'customer',
+      intent: 'view-product-detail',
+      user_input: userMessage,
+    });
+    return this.chat([{ role: 'system', content: prompt }]);
   }
 
   async generateBuyProductResponse(
     userMessage: string,
-    product?: CatalogItem,
+    product: CatalogItem | undefined,
+    storeName: string,
+    userName?: string,
   ): Promise<string> {
     if (product) {
       const domain = process.env.SHOPIFY_SHOP_DOMAIN;
       const link = domain && product.handle ? `https://${domain}/products/${product.handle}` : '';
-      const messages = [
-        {
-          role: 'system',
-          content:
-            `You are a helpful e-commerce assistant. Help the user purchase the product ${product.productName} (price: ${product.price}, vendor: ${product.vendor}). ${link ? 'Link: ' + link + '.' : ''}`,
-        },
-        { role: 'user', content: userMessage },
-      ];
-      return this.chat(messages);
+      const prompt = this.fillTemplate(this.templates.buyProduct, {
+        product_name: product.productName,
+        price: String(product.price),
+        vendor: product.vendor ?? '',
+        link: link ? `Link: ${link}.` : '',
+        store_name: storeName,
+        user_name: userName ?? 'customer',
+        intent: 'buy-product',
+        user_input: userMessage,
+      });
+      return this.chat([{ role: 'system', content: prompt }]);
     }
-    const messages = [
-      {
-        role: 'system',
-        content:
-          'You are a helpful e-commerce assistant. The requested product was not found.',
-      },
-      { role: 'user', content: userMessage },
-    ];
-    return this.chat(messages);
+    return this.generateProductNotFoundResponse(
+      userMessage,
+      'buy-product',
+      storeName,
+      userName,
+    );
+  }
+
+  async generateProductNotFoundResponse(
+    userMessage: string,
+    intent: string,
+    storeName: string,
+    userName?: string,
+  ): Promise<string> {
+    const prompt = this.fillTemplate(this.templates.productNotFound, {
+      store_name: storeName,
+      user_name: userName ?? 'customer',
+      intent,
+      user_input: userMessage,
+    });
+    return this.chat([{ role: 'system', content: prompt }]);
+  }
+
+  buildBasePrompt(options: {
+    storeName: string;
+    userName?: string;
+    intent: string;
+    userInput: string;
+  }): string {
+    return this.fillTemplate(this.templates.base, {
+      store_name: options.storeName,
+      user_name: options.userName ?? 'customer',
+      intent: options.intent,
+      user_input: options.userInput,
+    });
+  }
+
+  async chatWithBasePrompt(options: {
+    storeName: string;
+    userName?: string;
+    intent: string;
+    userInput: string;
+  }): Promise<string> {
+    const prompt = this.buildBasePrompt(options);
+    return this.chat([{ role: 'system', content: prompt }]);
   }
 }

--- a/src/prompt/base_prompt.txt
+++ b/src/prompt/base_prompt.txt
@@ -1,0 +1,8 @@
+You are an assistant of the store  {{store_name}} who answers questions for the users trying to explore your catalog, get more information for a product or buy a product.
+
+Your tone must be friendly and try to respond as you were a pet.
+The user name is {{user_name}} and the intent of the user is: {{intent}}.
+
+User message: {{user_input}}
+
+Reply in a clear and personalized way.

--- a/src/prompt/buy_product_prompt.txt
+++ b/src/prompt/buy_product_prompt.txt
@@ -1,0 +1,10 @@
+You are an assistant of the store  {{store_name}} who answers questions for the users trying to explore your catalog, get more information for a product or buy a product.
+
+Your tone must be friendly and try to respond as you were a pet.
+The user name is {{user_name}} and the intent of the user is: {{intent}}.
+
+Help the user purchase the product {{product_name}} (price: {{price}}, vendor: {{vendor}}). {{link}}
+
+User message: {{user_input}}
+
+Reply in a clear and friendly manner.

--- a/src/prompt/list_products_prompt.txt
+++ b/src/prompt/list_products_prompt.txt
@@ -1,0 +1,12 @@
+You are an assistant of the store  {{store_name}} who answers questions for the users trying to explore your catalog, get more information for a product or buy a product.
+
+Your tone must be friendly and try to respond as you were a pet.
+The user name is {{user_name}} and the intent of the user is: {{intent}}.
+
+Provide a concise list of products based on the catalog.
+
+Catalog: {{catalog_info}}
+
+User message: {{user_input}}
+
+Reply in a clear and friendly manner.

--- a/src/prompt/product_detail_prompt.txt
+++ b/src/prompt/product_detail_prompt.txt
@@ -1,0 +1,12 @@
+You are an assistant of the store  {{store_name}} who answers questions for the users trying to explore your catalog, get more information for a product or buy a product.
+
+Your tone must be friendly and try to respond as you were a pet.
+The user name is {{user_name}} and the intent of the user is: {{intent}}.
+
+Provide concise details about the product including the name, price, vendor and brief description. Mention that the product image is attached and do not disclose its URL. {{link}}
+
+Product: {{product_name}} (price: {{price}}, vendor: {{vendor}}). {{description}}
+
+User message: {{user_input}}
+
+Reply in a clear and friendly manner.

--- a/src/prompt/product_not_found_prompt.txt
+++ b/src/prompt/product_not_found_prompt.txt
@@ -1,0 +1,10 @@
+You are an assistant of the store  {{store_name}} who answers questions for the users trying to explore your catalog, get more information for a product or buy a product.
+
+Your tone must be friendly and try to respond as you were a pet.
+The user name is {{user_name}} and the intent of the user is: {{intent}}.
+
+The requested product was not found.
+
+User message: {{user_input}}
+
+Reply in a clear and friendly manner.

--- a/src/prompt/store_information_prompt.txt
+++ b/src/prompt/store_information_prompt.txt
@@ -1,0 +1,10 @@
+You are an assistant of the store  {{store_name}} who answers questions for the users trying to explore your catalog, get more information for a product or buy a product.
+
+Your tone must be friendly and try to respond as you were a pet.
+The user name is {{user_name}} and the intent of the user is: {{intent}}.
+
+Provide store information and policies for the store at {{store_domain}} without mentioning internal APIs.
+
+User message: {{user_input}}
+
+Reply in a clear and friendly manner.

--- a/src/twilio/whatsapp.service.ts
+++ b/src/twilio/whatsapp.service.ts
@@ -30,6 +30,8 @@ export class WhatsappService {
     const raw = await this.shopifyService.getProducts();
     const catalog = this.buildCatalog(raw.products ?? []);
 
+    const storeName = process.env.SHOPIFY_SHOP_DOMAIN || 'our store';
+
     const intent = await this.openaiService.analyzeIntent(userMessage);
 
     const emailRegex = /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/;
@@ -92,12 +94,16 @@ export class WhatsappService {
       case 'store-information':
         body = await this.openaiService.generateStoreInformationResponse(
           userMessage,
+          storeName,
+          user?.name,
         );
         break;
       case 'list-products':
         body = await this.openaiService.generateListProductsResponse(
           userMessage,
           catalog,
+          storeName,
+          user?.name,
         );
         break;
       case 'view-product-detail': {
@@ -108,31 +114,31 @@ export class WhatsappService {
         const product = matchedId
           ? catalog.find((p) => String(p.productId) === matchedId)
           : undefined;
-        if (product) {
-          body = await this.openaiService.generateProductDetailResponse(
-            userMessage,
-            product,
-          );
-          if (product.imageUrl) {
-            mediaUrl = product.imageUrl;
+          if (product) {
+            body = await this.openaiService.generateProductDetailResponse(
+              userMessage,
+              product,
+              storeName,
+              user?.name,
+            );
+            if (product.imageUrl) {
+              mediaUrl = product.imageUrl;
+            }
+            await this.memoryService.addProductInterest(from, String(product.productId));
+            const domain = process.env.SHOPIFY_SHOP_DOMAIN;
+            if (domain && product.handle) {
+              actionUrl = `https://${domain}/products/${product.handle}`;
+            }
+          } else {
+            body = await this.openaiService.generateProductNotFoundResponse(
+              userMessage,
+              'view-product-detail',
+              storeName,
+              user?.name,
+            );
           }
-          await this.memoryService.addProductInterest(from, String(product.productId));
-          const domain = process.env.SHOPIFY_SHOP_DOMAIN;
-          if (domain && product.handle) {
-            actionUrl = `https://${domain}/products/${product.handle}`;
-          }
-        } else {
-          body = await this.openaiService.chat([
-            {
-              role: 'system',
-              content:
-                'You are a helpful e-commerce assistant. The requested product was not found.',
-            },
-            { role: 'user', content: userMessage },
-          ]);
+          break;
         }
-        break;
-      }
       case 'buy-product': {
         const matchedId = await this.openaiService.matchProduct(
           userMessage,
@@ -144,6 +150,8 @@ export class WhatsappService {
         body = await this.openaiService.generateBuyProductResponse(
           userMessage,
           product,
+          storeName,
+          user?.name,
         );
         if (product?.imageUrl) {
           mediaUrl = product.imageUrl;
@@ -154,13 +162,12 @@ export class WhatsappService {
         break;
       }
       default:
-        body = await this.openaiService.chat([
-          {
-            role: 'system',
-            content: 'You are a helpful e-commerce assistant.',
-          },
-          { role: 'user', content: userMessage },
-        ]);
+        body = await this.openaiService.chatWithBasePrompt({
+          storeName: process.env.SHOPIFY_SHOP_DOMAIN || 'our store',
+          userName: user?.name,
+          intent,
+          userInput: userMessage,
+        });
     }
 
     return { body, mediaUrl, actionUrl };


### PR DESCRIPTION
## Summary
- include friendly pet-style intro in all intent prompt templates
- expand OpenAI service to inject store and user info into responses
- return not-found prompt via new helper
- pass store and user context from Whatsapp service

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6850fbb102248324b13afd2df546b655