### PR TITLE
Add memory of last viewed product

### DIFF
--- a/src/memory/memory.service.ts
+++ b/src/memory/memory.service.ts
@@ -6,6 +6,7 @@ export interface UserData {
   name?: string;
   email?: string;
   productInterests?: string[];
+  lastProductId?: string;
 }
 
 @Injectable()
@@ -48,6 +49,18 @@ export class MemoryService implements OnModuleDestroy {
     const set = new Set(user.productInterests ?? []);
     set.add(String(productId));
     user.productInterests = Array.from(set);
+    user.lastProductId = String(productId);
     await this.saveUser(user);
+  }
+
+  async setLastProduct(id: string, productId: string): Promise<void> {
+    const user = (await this.getUser(id)) || { id };
+    user.lastProductId = String(productId);
+    await this.saveUser(user);
+  }
+
+  async getLastProduct(id: string): Promise<string | undefined> {
+    const user = await this.getUser(id);
+    return user?.lastProductId;
   }
 }

--- a/src/openai/openai.service.ts
+++ b/src/openai/openai.service.ts
@@ -160,6 +160,7 @@ export class OpenaiService {
     product: CatalogItem,
     storeName: string,
     userName?: string,
+    lastProduct?: string,
   ): Promise<string> {
     const domain = process.env.SHOPIFY_SHOP_DOMAIN;
     const link = domain && product.handle ? `https://${domain}/products/${product.handle}` : '';
@@ -174,6 +175,7 @@ export class OpenaiService {
       description: description ? `Description: ${description}` : '',
       store_name: storeName,
       user_name: userName ?? 'customer',
+      last_product: lastProduct ?? '',
       intent: 'view-product-detail',
       user_input: userMessage,
     });
@@ -185,6 +187,7 @@ export class OpenaiService {
     product: CatalogItem | undefined,
     storeName: string,
     userName?: string,
+    lastProduct?: string,
   ): Promise<string> {
     if (product) {
       const domain = process.env.SHOPIFY_SHOP_DOMAIN;
@@ -196,6 +199,7 @@ export class OpenaiService {
         link: link ? `Link: ${link}.` : '',
         store_name: storeName,
         user_name: userName ?? 'customer',
+        last_product: lastProduct ?? '',
         intent: 'buy-product',
         user_input: userMessage,
       });

--- a/src/prompt/buy_product_prompt.txt
+++ b/src/prompt/buy_product_prompt.txt
@@ -3,6 +3,8 @@ You are an assistant of the store  {{store_name}} who answers questions for the 
 Your tone must be friendly and try to respond as you were a pet.
 The user name is {{user_name}} and the intent of the user is: {{intent}}.
 
+The last product the user viewed was {{last_product}}.
+
 Help the user purchase the product {{product_name}} (price: {{price}}, vendor: {{vendor}}). {{link}}
 
 User message: {{user_input}}

--- a/src/prompt/product_detail_prompt.txt
+++ b/src/prompt/product_detail_prompt.txt
@@ -3,6 +3,8 @@ You are an assistant of the store  {{store_name}} who answers questions for the 
 Your tone must be friendly and try to respond as you were a pet.
 The user name is {{user_name}} and the intent of the user is: {{intent}}.
 
+The last product the user viewed was {{last_product}}.
+
 Provide concise details about the product including the name, price, vendor and brief description. Mention that the product image is attached and do not disclose its URL. {{link}}
 
 Product: {{product_name}} (price: {{price}}, vendor: {{vendor}}). {{description}}


### PR DESCRIPTION
## Summary
- extend memory service to track user's last viewed product
- mention the last product in product detail and purchase prompts
- send the last viewed product info to OpenAI
- save last viewed product when users check a product detail or buy

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851046d7c848324aa6ca3946b0e5d49