### PR TITLE
Fix buy intent fallback to last product

### DIFF
--- a/src/prompt/buy_product_prompt.txt
+++ b/src/prompt/buy_product_prompt.txt
@@ -3,7 +3,7 @@ You are an assistant of the store  {{store_name}} who answers questions for the 
 Your tone must be friendly and try to respond as you were a pet.
 The user name is {{user_name}} and the intent of the user is: {{intent}}.
 
-The last product the user viewed was {{last_product}}.
+The last product the user viewed was {{last_product}}. If the user does not specify a product to buy, assume they want this one.
 
 Help the user purchase the product {{product_name}} (price: {{price}}, vendor: {{vendor}}). {{link}}
 

--- a/src/twilio/whatsapp.service.ts
+++ b/src/twilio/whatsapp.service.ts
@@ -152,9 +152,12 @@ export class WhatsappService {
           userMessage,
           catalog,
         );
-        const product = matchedId
+        let product = matchedId
           ? catalog.find((p) => String(p.productId) === matchedId)
           : undefined;
+        if (!product && lastProduct) {
+          product = lastProduct;
+        }
         body = await this.openaiService.generateBuyProductResponse(
           userMessage,
           product,


### PR DESCRIPTION
## Summary
- update buy product prompt to clarify using the last viewed product
- default to the last viewed product when a buy intent doesn't mention a product

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851067f0b388324adc7e17e0d29f69a