### PR TITLE
Add shopping cart and checkout intent

### DIFF
--- a/src/memory/memory.service.ts
+++ b/src/memory/memory.service.ts
@@ -7,6 +7,7 @@ export interface UserData {
   email?: string;
   productInterests?: string[];
   lastProductId?: string;
+  cart?: Record<string, number>;
 }
 
 @Injectable()
@@ -62,5 +63,27 @@ export class MemoryService implements OnModuleDestroy {
   async getLastProduct(id: string): Promise<string | undefined> {
     const user = await this.getUser(id);
     return user?.lastProductId;
+  }
+
+  async addToCart(id: string, productId: string): Promise<void> {
+    const user = (await this.getUser(id)) || { id, cart: {} } as UserData;
+    if (!user.cart) user.cart = {};
+    user.cart[productId] = (user.cart[productId] || 0) + 1;
+    await this.saveUser(user);
+  }
+
+  async getCart(id: string): Promise<{ productId: string; quantity: number }[]> {
+    const user = await this.getUser(id);
+    const cart = user?.cart ?? {};
+    return Object.entries(cart).map(([productId, quantity]) => ({
+      productId,
+      quantity: Number(quantity),
+    }));
+  }
+
+  async clearCart(id: string): Promise<void> {
+    const user = (await this.getUser(id)) || { id } as UserData;
+    user.cart = {};
+    await this.saveUser(user);
   }
 }

--- a/src/openai/openai.service.ts
+++ b/src/openai/openai.service.ts
@@ -43,6 +43,10 @@ export class OpenaiService {
       join(process.cwd(), 'src/prompt/product_not_found_prompt.txt'),
       'utf8',
     ),
+    checkout: readFileSync(
+      join(process.cwd(), 'src/prompt/checkout_prompt.txt'),
+      'utf8',
+    ),
   } as const;
 
   private fillTemplate(
@@ -109,7 +113,7 @@ export class OpenaiService {
       {
         role: 'system',
         content:
-          'Identify the user intent. Possible intents: hello, store-information, list-products, view-product-detail, buy-product. ' +
+          'Identify the user intent. Possible intents: hello, store-information, list-products, view-product-detail, buy-product, checkout. ' +
           'Reply ONLY with one of the intent labels.',
       },
       { role: 'user', content: userMessage },
@@ -211,6 +215,24 @@ export class OpenaiService {
       storeName,
       userName,
     );
+  }
+
+  async generateCheckoutResponse(
+    userMessage: string,
+    cartSummary: string,
+    checkoutLink: string,
+    storeName: string,
+    userName?: string,
+  ): Promise<string> {
+    const prompt = this.fillTemplate(this.templates.checkout, {
+      cart_items: cartSummary,
+      checkout_link: checkoutLink ? `Checkout link: ${checkoutLink}.` : '',
+      store_name: storeName,
+      user_name: userName ?? 'customer',
+      intent: 'checkout',
+      user_input: userMessage,
+    });
+    return this.chat([{ role: 'system', content: prompt }]);
   }
 
   async generateProductNotFoundResponse(

--- a/src/prompt/checkout_prompt.txt
+++ b/src/prompt/checkout_prompt.txt
@@ -1,0 +1,10 @@
+You are an assistant of the store  {{store_name}} who answers questions for the users trying to explore your catalog, get more information for a product or buy a product.
+
+Your tone must be friendly and try to respond as you were a pet.
+The user name is {{user_name}} and the intent of the user is: {{intent}}.
+
+The user's shopping cart contains: {{cart_items}}. {{checkout_link}}
+
+User message: {{user_input}}
+
+Reply in a clear and friendly manner.


### PR DESCRIPTION
## Summary
- track cart items per user in Redis memory service
- detect new `checkout` intent via OpenAI and respond with cart summary
- add `addToCart`, `getCart`, and `clearCart` methods
- generate checkout responses and new prompt template
- update WhatsApp flow to add items to cart on buy intent and handle checkout

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68510aaac3988324a4a2b09243269378