### PR TITLE
Switch checkout link to variant IDs

### DIFF
--- a/src/openai/openai.service.ts
+++ b/src/openai/openai.service.ts
@@ -6,6 +6,7 @@ import { join } from 'path';
 export interface CatalogItem {
   productName: string;
   productId: string | number;
+  variantId?: string | number;
   handle?: string;
   imageUrl?: string | null;
   price?: string | number;

--- a/src/twilio/whatsapp.service.ts
+++ b/src/twilio/whatsapp.service.ts
@@ -15,6 +15,7 @@ export class WhatsappService {
     return raw.map((p: any) => ({
       productName: p.title,
       productId: p.id,
+      variantId: p.variants?.[0]?.id,
       handle: p.handle,
       imageUrl: p.image?.src ?? p.images?.[0]?.src ?? null,
       price: p.variants?.[0]?.price,
@@ -197,7 +198,13 @@ export class WhatsappService {
         const domain = process.env.SHOPIFY_SHOP_DOMAIN;
         const link = domain
           ? `https://${domain}/cart/${cartItems
-              .map((i) => `${i.productId}:${i.quantity}`)
+              .map((i) => {
+                const prod = catalog.find(
+                  (p) => String(p.productId) === String(i.productId),
+                );
+                const variant = prod?.variantId ?? i.productId;
+                return `${variant}:${i.quantity}`;
+              })
               .join(',')}`
           : '';
         body = await this.openaiService.generateCheckoutResponse(


### PR DESCRIPTION
## Summary
- track variant IDs in the catalog
- use variant IDs when composing the Shopify cart link

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68510d6c67e083249f3f91ccfca9492c